### PR TITLE
feat(live): system prompt support + lower video latency (v0.5.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.16] - 2026-06-14
+
+### Added
+- **Live API system prompt (`systemInstruction`) support**: Live sessions can now be given a role/persona/task instruction that is injected into the upstream Vertex/Gemini `BidiGenerateContentSetup` as `systemInstruction.parts[0].text`. Resolution order (highest first):
+  1. **Per-session override** — `setup.system_prompt` (string) in the client setup message, so a client (e.g. a rover/voice app) can set task-specific instructions per session without redeploying.
+  2. **Config default** — `live.system_prompt`, or `live.system_prompt_file` (path, loaded when the inline prompt is empty; supports `~`). Env: `PEPEBOT_LIVE_SYSTEM_PROMPT` / `PEPEBOT_LIVE_SYSTEM_PROMPT_FILE`.
+  3. **Agent persona fallback (opt-in)** — when `live.use_agent_prompt: true` (env `PEPEBOT_LIVE_USE_AGENT_PROMPT`) and no explicit prompt is set, the selected agent's persona files (`AGENTS.md` → `SOUL.md` → `IDENTITY.md`, agent dir then workspace) are used, keeping persona consistent between text and Live.
+  - Implemented in `pkg/config/config.go` (new `LiveConfig` fields + file loading in `LoadConfig`), `pkg/live/vertex_live.go` & `pkg/live/gemini_live.go` (`SetupMessage` injects the config prompt), and `pkg/live/live.go` (`SetupConfig.SystemPrompt`, `injectGeminiSystemInstruction`, precedence resolution, and the optional `SystemPromptSource` interface implemented by `AgentManager.LiveSystemPrompt`).
+  - **No regression when unset**: if no prompt resolves from any source, the upstream setup is byte-identical to before (no `systemInstruction` added). Works for both `vertex` and `gemini` providers.
+
+## [0.5.15] - 2026-06-14
+
+### Changed
+- **Live API video latency tuning**: Reduced the delay between showing an image to the camera and the model actually "seeing"/responding to it on Vertex/Gemini Live sessions.
+  - **Faster turn commit**: Default `automaticActivityDetection.endOfSpeechSensitivity` changed from `END_SENSITIVITY_LOW` to `END_SENSITIVITY_HIGH`, and a `silenceDurationMs: 500` default was added. Because the model only processes the latest video frame when a turn commits (end-of-speech), a shorter silence window means it reacts to images noticeably sooner.
+  - **Lower media resolution by default**: New `live.media_resolution` config field (default `MEDIA_RESOLUTION_LOW`, ~280 tokens/frame) injected into `generationConfig.mediaResolution`, cutting per-frame token cost and inference latency. Configurable via `PEPEBOT_LIVE_MEDIA_RESOLUTION`; not overridden if `generation_config` already pins `mediaResolution`.
+
+### Added
+- **Snapshot in video example client**: `examples/live-api/index-video.html` gains a **Snapshot** button that sends the current camera frame as `clientContent` with `turnComplete: true`, forcing the model to look at the image and answer immediately instead of waiting for voice-activity end-of-turn detection.
+
+### Fixed
+- **Tool calls no longer stall Live audio/video**: `handleUpstreamToolCalls` now runs off the upstream→client proxy loop in a goroutine. Previously a slow tool call (timeout up to 90s) blocked forwarding of the model's audio responses and subsequent frames; tool responses remain serialized via the session's upstream mutex so concurrent writes stay safe.
+
 ## [0.5.14] - 2026-04-29
 
 ### Fixed

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,12 +1,38 @@
-# 🐸 Pepebot v0.5.14 - Discord Message Cleanup
+# 🐸 Pepebot v0.5.16 - Give Your Live Session a Role
 
-**Release Date:** 2026-04-29
+**Release Date:** 2026-06-14
 
 ## 🎉 What's New
 
-### 💬 Cleaner Discord Messages
+### 🧠 System prompts for the Live API
 
-Long messages sent by the bot in Discord are split into multiple chunks to stay within Discord's character limit. Previously each chunk showed a `[Part 1/3]`, `[Part 2/3]` header — now those headers are gone, making the conversation feel more natural.
+Live voice/vision sessions can finally be told *how to behave*. Set a role, persona, or task and the Vertex/Gemini Live model follows it:
+
+- **Config default** — `live.system_prompt` (or `live.system_prompt_file`, env `PEPEBOT_LIVE_SYSTEM_PROMPT`).
+- **Per-session override** — a client can pass `system_prompt` in its `setup` message, perfect for task-specific clients (e.g. an autonomous rover that sets its mission per run).
+- **Reuse your agent's persona** — flip `live.use_agent_prompt: true` and the Live session inherits the selected agent's `AGENTS.md`/`SOUL.md`/`IDENTITY.md`, so it sounds the same in chat and in voice.
+
+If you set nothing, behavior is unchanged — no surprises.
+
+```json
+{ "live": { "system_prompt": "You are LEXA, an autonomous rover. Perceive → act → repeat, avoid obstacles, stop on command. Narrate briefly." } }
+```
+
+---
+
+## 🎉 Previous Highlights
+
+### 👁️ Live API sees your camera faster
+
+When you stream your camera to a Live session (Vertex/Gemini), the model now reacts to what it sees much sooner:
+
+- **Faster turn-taking** — the assistant decides you've stopped talking quicker (`END_SENSITIVITY_HIGH` + a shorter `silenceDurationMs: 500`), so it looks at the latest frame and replies with less lag.
+- **Lighter frames** — video frames default to `MEDIA_RESOLUTION_LOW` (~280 tokens each), cutting cost and inference latency. Tune it via `live.media_resolution` or `PEPEBOT_LIVE_MEDIA_RESOLUTION`.
+- **📸 Snapshot button** — the video example (`examples/live-api/index-video.html`) now has a **Snapshot** button that pushes the current frame as a committed turn, forcing an instant "look at this now" without waiting for you to finish speaking.
+
+### 🛠️ Tool calls no longer freeze the conversation
+
+A slow tool call during a Live session used to block the model's audio and incoming video frames. Tool calls now run off the proxy loop, so audio and video keep flowing smoothly while a tool runs.
 
 ---
 

--- a/cmd/pepebot/main.go
+++ b/cmd/pepebot/main.go
@@ -38,7 +38,7 @@ import (
 	"github.com/pepebot-space/pepebot/pkg/workflow"
 )
 
-const version = "0.5.14"
+const version = "0.5.16"
 const logo = "🐸"
 
 func copyDirectory(src, dst string) error {

--- a/docs/live-api.md
+++ b/docs/live-api.md
@@ -112,6 +112,93 @@ Jika koneksi dan inisialisasi berhasil, Pepebot Server akan membalas dengan stat
 - Untuk Vertex/Gemini: `{"setupComplete": true}` atau respon ekuivalen yang menandakan Live session siap.
 - Untuk OpenAI / MAIA Router: `{"status": "connected", "provider": "openai", "model": "gpt-4o-realtime-preview", "session": "..."}`. Setelah menerima respons ini, klien dapat mulai mengirimkan *frame* mengikuti skema spesifik dari provider tersebut.
 
+### Tuning Latency Video (kapan model "melihat" gambar)
+
+Pada Vertex/Gemini, frame kamera dikirim sebagai `realtimeInput` (streaming kontinu). Model **tidak** memproses tiap frame seketika — ia hanya "melihat" frame terbaru saat *turn* di-commit, yaitu ketika *Voice Activity Detection* (VAD) mendeteksi Anda berhenti bicara. Jadi delay yang terasa sebagian besar berasal dari konfigurasi turn-taking, bukan dari proxy Pepebot (yang transparan).
+
+Tiga knob yang memengaruhi delay (semua opsional, punya default yang baik):
+
+```json
+{
+  "live": {
+    "media_resolution": "MEDIA_RESOLUTION_LOW",
+    "generation_config": {},
+    "realtime_input_config": {
+      "automaticActivityDetection": {
+        "disabled": false,
+        "startOfSpeechSensitivity": "START_SENSITIVITY_LOW",
+        "endOfSpeechSensitivity": "END_SENSITIVITY_HIGH",
+        "prefixPaddingMs": 80,
+        "silenceDurationMs": 500
+      }
+    }
+  }
+}
+```
+
+| Field | Efek | Default Pepebot |
+|-------|------|-----------------|
+| `media_resolution` | `MEDIA_RESOLUTION_LOW` ≈ 280 token/gambar → inferensi lebih cepat & murah; `MEDIUM/HIGH` lebih detail tapi lebih lambat. Disuntikkan otomatis ke `generationConfig.mediaResolution` bila belum di-set. | `MEDIA_RESOLUTION_LOW` |
+| `endOfSpeechSensitivity` | `END_SENSITIVITY_HIGH` = lebih cepat memutuskan ucapan selesai → turn cepat commit → gambar cepat diproses. `LOW` menunggu lebih lama. | `END_SENSITIVITY_HIGH` |
+| `silenceDurationMs` | Lama hening sebelum turn dianggap selesai. Makin kecil makin responsif, tapi terlalu kecil bisa memotong ucapan. | `500` |
+
+> ⚠️ Jika `realtime_input_config` Anda set eksplisit di `config.json`, isinya **menggantikan** default (bukan merge). Pastikan menyertakan `endOfSpeechSensitivity`/`silenceDurationMs` yang diinginkan.
+
+**Snapshot (lihat sekarang juga):** untuk memaksa model melihat satu frame seketika tanpa menunggu VAD, kirim frame sebagai `clientContent` dengan `turnComplete: true` (bukan `realtimeInput`). Contoh di `examples/live-api/index-video.html` punya tombol **Snapshot**:
+
+```json
+{
+  "clientContent": {
+    "turns": [{ "role": "user", "parts": [
+      { "inlineData": { "mimeType": "image/jpeg", "data": "<base64 jpeg>" } },
+      { "text": "apa yang saya pegang?" }
+    ]}],
+    "turnComplete": true
+  }
+}
+```
+
+### System Prompt (`systemInstruction`)
+
+Anda bisa memberi peran/persona/instruksi tugas ke model Live (Vertex/Gemini) lewat `systemInstruction`. Pepebot menyusunnya dengan urutan presedensi:
+
+1. **Per-sesi (paling tinggi)** — field `system_prompt` di pesan `setup` dari klien.
+2. **Config default** — `live.system_prompt` (atau `live.system_prompt_file`; env `PEPEBOT_LIVE_SYSTEM_PROMPT`).
+3. **Persona agent (opsional)** — bila `live.use_agent_prompt: true`, fallback ke file persona agent terpilih (`AGENTS.md` → `SOUL.md` → `IDENTITY.md`, cek di direktori agent lalu workspace).
+
+Jika tidak ada satu pun yang di-set, perilaku **identik** seperti sebelumnya (upstream setup tanpa `systemInstruction`, tanpa regresi).
+
+**Config default:**
+
+```json
+{
+  "live": {
+    "enabled": true,
+    "provider": "vertex",
+    "model": "gemini-live-2.5-flash-native-audio",
+    "video": true,
+    "system_prompt": "You are LEXA, an autonomous rover. You can see the camera and call rover tools. Given a goal, work toward it in a perceive→act→perceive loop with small bounded steps; avoid obstacles (back off + turn on blocked); stop immediately when asked. Narrate briefly."
+  }
+}
+```
+
+- Alternatif dari file: `"system_prompt_file": "~/.pepebot/lexa.md"` (dipakai hanya bila `system_prompt` kosong; mendukung `~`).
+- Pakai persona agent: `"use_agent_prompt": true` (hanya berlaku jika `system_prompt`/`system_prompt_file` kosong).
+
+**Override per-sesi (dari klien):**
+
+```json
+{ "setup": { "provider": "vertex", "model": "gemini-live-2.5-flash-native-audio",
+             "agent": "default", "enable_tools": true,
+             "system_prompt": "You are LEXA, an autonomous rover ..." } }
+```
+
+Hasilnya, `BidiGenerateContentSetup` upstream akan menyertakan:
+
+```json
+{ "setup": { "systemInstruction": { "parts": [ { "text": "<PROMPT>" } ] }, "model": "...", "generationConfig": {} } }
+```
+
 ---
 
 ## 4. Pengiriman Audio dan Teks

--- a/examples/live-api/index-video.html
+++ b/examples/live-api/index-video.html
@@ -55,6 +55,7 @@
 
         <div class="flex gap-2">
           <input id="textInput" class="flex-1 rounded-lg bg-slate-800 border border-slate-700 px-3 py-2 text-sm" placeholder="Type message..." />
+          <button id="snapshotBtn" class="rounded-lg px-4 bg-amber-600 hover:bg-amber-500" title="Send current frame now and force the model to look (clientContent + turnComplete)">Snapshot</button>
           <button id="sendBtn" class="rounded-lg px-4 bg-indigo-700 hover:bg-indigo-600">Send</button>
         </div>
 
@@ -71,6 +72,7 @@
     const startCamBtn = document.getElementById('startCamBtn');
     const stopCamBtn = document.getElementById('stopCamBtn');
     const sendBtn = document.getElementById('sendBtn');
+    const snapshotBtn = document.getElementById('snapshotBtn');
     const textInput = document.getElementById('textInput');
     const logs = document.getElementById('logs');
     const statusEl = document.getElementById('status');
@@ -436,6 +438,37 @@
       }));
     }
 
+    // Snapshot: send the current frame as a committed turn (clientContent +
+    // turnComplete) so the model looks at the image and answers immediately,
+    // instead of waiting for end-of-speech detection on the realtimeInput stream.
+    function sendSnapshot() {
+      if (!ws || ws.readyState !== WebSocket.OPEN) {
+        log('Connect first', 'error');
+        return;
+      }
+      if (!camCanvas || !camCtx || !camPreview.videoWidth || !camPreview.videoHeight) {
+        log('Start the camera first', 'error');
+        return;
+      }
+
+      camCtx.drawImage(camPreview, 0, 0, VIDEO_WIDTH, VIDEO_HEIGHT);
+      const b64 = base64FromJpegDataUrl(camCanvas.toDataURL('image/jpeg', JPEG_QUALITY));
+      if (!b64) return;
+
+      const text = textInput.value.trim();
+      const parts = [{ inlineData: { mimeType: VIDEO_MIME, data: b64 } }];
+      if (text) parts.push({ text });
+
+      ws.send(JSON.stringify({
+        clientContent: {
+          turns: [{ role: 'user', parts }],
+          turnComplete: true,
+        },
+      }));
+      log(text ? `Snapshot + "${text}" sent` : 'Snapshot sent', 'ok');
+      if (text) textInput.value = '';
+    }
+
     async function startCamera() {
       if (!ws || ws.readyState !== WebSocket.OPEN) {
         log('Connect first', 'error');
@@ -496,6 +529,7 @@
     disconnectBtn.addEventListener('click', disconnect);
     startMicBtn.addEventListener('click', startMic);
     stopMicBtn.addEventListener('click', stopMic);
+    snapshotBtn.addEventListener('click', sendSnapshot);
     startCamBtn.addEventListener('click', startCamera);
     stopCamBtn.addEventListener('click', stopCamera);
     sendBtn.addEventListener('click', sendText);

--- a/pkg/agent/manager.go
+++ b/pkg/agent/manager.go
@@ -3,6 +3,8 @@ package agent
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -229,6 +231,39 @@ func (am *AgentManager) GetToolDefinitions(agentName string) ([]map[string]inter
 	}
 
 	return agentLoop.ToolDefinitions(), nil
+}
+
+// LiveSystemPrompt returns the selected agent's persona text for use as a Live
+// systemInstruction. It reads AGENTS.md/SOUL.md/IDENTITY.md from the agent's
+// prompt dir, falling back to the workspace root per file. Returns "" when none
+// exist. Used only when live.use_agent_prompt is enabled and no explicit prompt
+// is set.
+func (am *AgentManager) LiveSystemPrompt(agentName string) string {
+	if agentName == "" {
+		agentName = am.defaultAgent
+	}
+
+	agentDir := am.registry.AgentPromptDir(agentName)
+	workspace := am.config.WorkspacePath()
+
+	var b strings.Builder
+	for _, name := range []string{"AGENTS.md", "SOUL.md", "IDENTITY.md"} {
+		var data []byte
+		if agentDir != "" {
+			data, _ = os.ReadFile(filepath.Join(agentDir, name))
+		}
+		if len(data) == 0 {
+			data, _ = os.ReadFile(filepath.Join(workspace, name))
+		}
+		if len(data) > 0 {
+			if b.Len() > 0 {
+				b.WriteString("\n\n")
+			}
+			b.Write(data)
+		}
+	}
+
+	return strings.TrimSpace(b.String())
 }
 
 // ExecuteTool executes a tool using the selected agent's tool registry.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/caarlos0/env/v11"
@@ -144,11 +145,19 @@ type GatewayConfig struct {
 }
 
 type LiveConfig struct {
-	Enabled             bool                   `json:"enabled" env:"PEPEBOT_LIVE_ENABLED"`
-	Provider            string                 `json:"provider" env:"PEPEBOT_LIVE_PROVIDER"`
-	Model               string                 `json:"model" env:"PEPEBOT_LIVE_MODEL"`
-	Video               bool                   `json:"video,omitempty" env:"PEPEBOT_LIVE_VIDEO"`
-	Language            string                 `json:"language,omitempty" env:"PEPEBOT_LIVE_LANGUAGE"`
+	Enabled         bool   `json:"enabled" env:"PEPEBOT_LIVE_ENABLED"`
+	Provider        string `json:"provider" env:"PEPEBOT_LIVE_PROVIDER"`
+	Model           string `json:"model" env:"PEPEBOT_LIVE_MODEL"`
+	Video           bool   `json:"video,omitempty" env:"PEPEBOT_LIVE_VIDEO"`
+	Language        string `json:"language,omitempty" env:"PEPEBOT_LIVE_LANGUAGE"`
+	MediaResolution string `json:"media_resolution,omitempty" env:"PEPEBOT_LIVE_MEDIA_RESOLUTION"`
+	// SystemPrompt sets the upstream systemInstruction for Live sessions (role/persona/task).
+	SystemPrompt string `json:"system_prompt,omitempty" env:"PEPEBOT_LIVE_SYSTEM_PROMPT"`
+	// SystemPromptFile loads the system prompt from a file when SystemPrompt is empty.
+	SystemPromptFile string `json:"system_prompt_file,omitempty" env:"PEPEBOT_LIVE_SYSTEM_PROMPT_FILE"`
+	// UseAgentPrompt, when true, falls back to the selected agent's persona files
+	// (AGENTS.md/SOUL.md/IDENTITY.md) as the Live systemInstruction if none is set.
+	UseAgentPrompt      bool                   `json:"use_agent_prompt,omitempty" env:"PEPEBOT_LIVE_USE_AGENT_PROMPT"`
 	GenerationConfig    map[string]interface{} `json:"generation_config,omitempty"`
 	RealtimeInputConfig map[string]interface{} `json:"realtime_input_config,omitempty"`
 }
@@ -232,6 +241,9 @@ func DefaultConfig() *Config {
 			Model:    "gemini-live-2.5-flash-native-audio",
 			Video:    false,
 			Language: "",
+			// Low media resolution = ~280 tokens/frame, lower latency for the
+			// model to "see" each video frame (vs medium/high).
+			MediaResolution: "MEDIA_RESOLUTION_LOW",
 			GenerationConfig: map[string]interface{}{
 				"responseModalities": []interface{}{"AUDIO"},
 				"speechConfig": map[string]interface{}{
@@ -246,7 +258,10 @@ func DefaultConfig() *Config {
 				"automaticActivityDetection": map[string]interface{}{
 					"disabled":                 false,
 					"startOfSpeechSensitivity": "START_SENSITIVITY_LOW",
-					"endOfSpeechSensitivity":   "END_SENSITIVITY_LOW",
+					// HIGH + shorter silence window = turn commits sooner, so the
+					// model processes the latest frame and responds with less delay.
+					"endOfSpeechSensitivity": "END_SENSITIVITY_HIGH",
+					"silenceDurationMs":      500,
 				},
 			},
 		},
@@ -283,6 +298,13 @@ func LoadConfig(path string) (*Config, error) {
 
 	// Overlay native provider environment variables (higher priority)
 	overlayNativeEnvVars(cfg)
+
+	// Load the Live system prompt from file when set and no inline prompt given.
+	if cfg.Live.SystemPrompt == "" && cfg.Live.SystemPromptFile != "" {
+		if promptData, ferr := os.ReadFile(expandHome(cfg.Live.SystemPromptFile)); ferr == nil {
+			cfg.Live.SystemPrompt = strings.TrimSpace(string(promptData))
+		}
+	}
 
 	return cfg, nil
 }

--- a/pkg/live/gemini_live.go
+++ b/pkg/live/gemini_live.go
@@ -60,8 +60,13 @@ func (p *GeminiLiveProvider) SetupMessage(model string) []byte {
 		"model": "models/" + model,
 	}
 
+	// Build generationConfig into a fresh map so injecting mediaResolution never
+	// mutates the shared config across sessions.
+	genCfg := map[string]interface{}{}
 	if p.liveConfig.GenerationConfig != nil {
-		setupInner["generationConfig"] = p.liveConfig.GenerationConfig
+		for k, v := range p.liveConfig.GenerationConfig {
+			genCfg[k] = v
+		}
 	} else {
 		speechConfig := map[string]interface{}{
 			"voiceConfig": map[string]interface{}{
@@ -73,15 +78,36 @@ func (p *GeminiLiveProvider) SetupMessage(model string) []byte {
 		if p.liveConfig.Language != "" {
 			speechConfig["languageCode"] = p.liveConfig.Language
 		}
-
-		setupInner["generationConfig"] = map[string]interface{}{
-			"responseModalities": []string{"AUDIO"},
-			"speechConfig":       speechConfig,
+		genCfg["responseModalities"] = []string{"AUDIO"}
+		genCfg["speechConfig"] = speechConfig
+	}
+	// Inject media resolution (lower = fewer tokens/frame, lower latency) unless
+	// the config already pins it explicitly.
+	if mr := p.liveConfig.MediaResolution; mr != "" {
+		if _, ok := genCfg["mediaResolution"]; !ok {
+			genCfg["mediaResolution"] = mr
 		}
 	}
+	setupInner["generationConfig"] = genCfg
 
 	if p.liveConfig.RealtimeInputConfig != nil {
 		setupInner["realtimeInputConfig"] = p.liveConfig.RealtimeInputConfig
+	} else {
+		setupInner["realtimeInputConfig"] = map[string]interface{}{
+			"automaticActivityDetection": map[string]interface{}{
+				"disabled":                 false,
+				"startOfSpeechSensitivity": "START_SENSITIVITY_LOW",
+				"endOfSpeechSensitivity":   "END_SENSITIVITY_HIGH",
+				"silenceDurationMs":        500,
+			},
+		}
+	}
+
+	// Set the system instruction (role/persona/task) when configured.
+	if prompt := p.liveConfig.SystemPrompt; prompt != "" {
+		setupInner["systemInstruction"] = map[string]interface{}{
+			"parts": []map[string]interface{}{{"text": prompt}},
+		}
 	}
 
 	setup := map[string]interface{}{

--- a/pkg/live/live.go
+++ b/pkg/live/live.go
@@ -39,6 +39,13 @@ type ToolExecutor interface {
 	ExecuteTool(ctx context.Context, agentName, toolName string, args map[string]interface{}) (string, error)
 }
 
+// SystemPromptSource optionally supplies an agent's persona prompt for use as the
+// Live systemInstruction. A ToolExecutor may implement it; resolution is opt-in
+// via live.use_agent_prompt and only used when no explicit prompt is set.
+type SystemPromptSource interface {
+	LiveSystemPrompt(agentName string) string
+}
+
 // SetupMessage is the first message sent by the client to configure the session
 type SetupMessage struct {
 	Setup *SetupConfig `json:"setup,omitempty"`
@@ -54,6 +61,8 @@ type SetupConfig struct {
 	// EnableTools controls whether gateway-side tool execution is enabled for the session.
 	// Defaults to true when omitted.
 	EnableTools *bool `json:"enable_tools,omitempty"`
+	// SystemPrompt sets the session systemInstruction (highest precedence override).
+	SystemPrompt string `json:"system_prompt,omitempty"`
 }
 
 // LiveServer manages WebSocket live sessions
@@ -281,6 +290,31 @@ func (ls *LiveServer) handleConnection(clientConn *websocket.Conn) {
 		}
 	}
 
+	// Resolve the session systemInstruction with precedence:
+	//   client setup.system_prompt > live.system_prompt(/_file) > agent persona.
+	// SetupMessage already injects the config prompt; re-injecting is idempotent.
+	// When nothing resolves, setupData is left untouched (byte-identical to before).
+	sysPrompt := strings.TrimSpace(setupMsg.Setup.SystemPrompt)
+	promptSource := "client"
+	if sysPrompt == "" {
+		sysPrompt = strings.TrimSpace(ls.config.Live.SystemPrompt)
+		promptSource = "config"
+	}
+	if sysPrompt == "" && ls.config.Live.UseAgentPrompt && ls.tools != nil {
+		if src, ok := ls.tools.(SystemPromptSource); ok {
+			sysPrompt = strings.TrimSpace(src.LiveSystemPrompt(agentName))
+			promptSource = "agent"
+		}
+	}
+	if sysPrompt != "" && setupData != nil {
+		setupData = injectGeminiSystemInstruction(setupData, sysPrompt)
+		logger.InfoCF("live", "Applied system instruction", map[string]interface{}{
+			"agent":  agentName,
+			"source": promptSource,
+			"chars":  len(sysPrompt),
+		})
+	}
+
 	if setupData != nil {
 		if err := upstreamConn.WriteMessage(websocket.TextMessage, setupData); err != nil {
 			logger.ErrorCF("live", "Failed to send upstream setup message", map[string]interface{}{
@@ -380,7 +414,10 @@ func (ls *LiveServer) proxyMessages(ctx context.Context, session *LiveSession, s
 		}
 
 		if direction == "upstream→client" {
-			ls.handleUpstreamToolCalls(ctx, session, msgType, data)
+			// Run tool calls off the proxy loop so a slow tool (up to 90s) never
+			// stalls forwarding of audio/video frames. The toolResponse write is
+			// serialized via session.upstreamMu, so concurrent writes stay safe.
+			go ls.handleUpstreamToolCalls(ctx, session, msgType, data)
 		}
 
 		var writeErr error
@@ -542,6 +579,34 @@ func injectGeminiToolsIntoSetup(setupData []byte, toolDefs []map[string]interfac
 
 	setupInner["tools"] = []map[string]interface{}{
 		{"functionDeclarations": functionDecls},
+	}
+
+	b, err := json.Marshal(setup)
+	if err != nil {
+		return setupData
+	}
+	return b
+}
+
+// injectGeminiSystemInstruction sets setup.systemInstruction.parts[0].text on a
+// Gemini/Vertex BidiGenerateContentSetup payload, replacing any existing value.
+func injectGeminiSystemInstruction(setupData []byte, prompt string) []byte {
+	if len(setupData) == 0 || prompt == "" {
+		return setupData
+	}
+
+	var setup map[string]interface{}
+	if err := json.Unmarshal(setupData, &setup); err != nil {
+		return setupData
+	}
+
+	setupInner, ok := setup["setup"].(map[string]interface{})
+	if !ok {
+		return setupData
+	}
+
+	setupInner["systemInstruction"] = map[string]interface{}{
+		"parts": []map[string]interface{}{{"text": prompt}},
 	}
 
 	b, err := json.Marshal(setup)

--- a/pkg/live/systemprompt_test.go
+++ b/pkg/live/systemprompt_test.go
@@ -1,0 +1,76 @@
+package live
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/pepebot-space/pepebot/pkg/config"
+)
+
+// setupSystemInstructionText extracts setup.systemInstruction.parts[0].text from a
+// BidiGenerateContentSetup payload, returning ("", false) when absent.
+func setupSystemInstructionText(t *testing.T, data []byte) (string, bool) {
+	t.Helper()
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("invalid setup JSON: %v", err)
+	}
+	inner, ok := m["setup"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("missing setup object")
+	}
+	si, ok := inner["systemInstruction"].(map[string]interface{})
+	if !ok {
+		return "", false
+	}
+	parts, ok := si["parts"].([]interface{})
+	if !ok || len(parts) == 0 {
+		t.Fatalf("systemInstruction has no parts")
+	}
+	p0, _ := parts[0].(map[string]interface{})
+	txt, _ := p0["text"].(string)
+	return txt, true
+}
+
+func TestSetupMessageSystemInstructionFromConfig(t *testing.T) {
+	const prompt = "You are LEXA, an autonomous rover."
+	p := &GeminiLiveProvider{liveConfig: config.LiveConfig{SystemPrompt: prompt}}
+
+	txt, present := setupSystemInstructionText(t, p.SetupMessage("gemini-live-2.5-flash-native-audio"))
+	if !present {
+		t.Fatal("expected systemInstruction when live.system_prompt is set")
+	}
+	if txt != prompt {
+		t.Fatalf("systemInstruction text = %q, want %q", txt, prompt)
+	}
+}
+
+func TestSetupMessageNoSystemInstructionWhenUnset(t *testing.T) {
+	p := &GeminiLiveProvider{liveConfig: config.LiveConfig{}}
+
+	if _, present := setupSystemInstructionText(t, p.SetupMessage("gemini-live-2.5-flash-native-audio")); present {
+		t.Fatal("expected no systemInstruction when no prompt configured (byte-identical/no regression)")
+	}
+}
+
+func TestInjectGeminiSystemInstruction(t *testing.T) {
+	base := []byte(`{"setup":{"model":"m","generationConfig":{}}}`)
+
+	// Empty prompt is a no-op.
+	if got := injectGeminiSystemInstruction(base, ""); string(got) != string(base) {
+		t.Fatalf("empty prompt should not modify setup; got %s", got)
+	}
+
+	// Non-empty prompt is injected/replaced.
+	out := injectGeminiSystemInstruction(base, "be a rover")
+	txt, present := setupSystemInstructionText(t, out)
+	if !present || txt != "be a rover" {
+		t.Fatalf("inject failed: present=%v text=%q", present, txt)
+	}
+
+	// Override replaces an existing instruction.
+	out2 := injectGeminiSystemInstruction(out, "be a drone")
+	if txt2, _ := setupSystemInstructionText(t, out2); txt2 != "be a drone" {
+		t.Fatalf("override failed: text=%q want %q", txt2, "be a drone")
+	}
+}

--- a/pkg/live/vertex_live.go
+++ b/pkg/live/vertex_live.go
@@ -94,9 +94,13 @@ func (p *VertexLiveProvider) SetupMessage(model string) []byte {
 		"model": modelResource,
 	}
 
-	// Use config-provided generationConfig, or defaults
+	// Use config-provided generationConfig, or defaults. Build into a fresh map
+	// so injecting mediaResolution never mutates the shared config across sessions.
+	genCfg := map[string]interface{}{}
 	if p.liveConfig.GenerationConfig != nil {
-		setupInner["generationConfig"] = p.liveConfig.GenerationConfig
+		for k, v := range p.liveConfig.GenerationConfig {
+			genCfg[k] = v
+		}
 	} else {
 		speechConfig := map[string]interface{}{
 			"voiceConfig": map[string]interface{}{
@@ -108,12 +112,17 @@ func (p *VertexLiveProvider) SetupMessage(model string) []byte {
 		if p.liveConfig.Language != "" {
 			speechConfig["languageCode"] = p.liveConfig.Language
 		}
-
-		setupInner["generationConfig"] = map[string]interface{}{
-			"responseModalities": []string{"AUDIO"},
-			"speechConfig":       speechConfig,
+		genCfg["responseModalities"] = []string{"AUDIO"}
+		genCfg["speechConfig"] = speechConfig
+	}
+	// Inject media resolution (lower = fewer tokens/frame, lower latency) unless
+	// the config already pins it explicitly.
+	if mr := p.liveConfig.MediaResolution; mr != "" {
+		if _, ok := genCfg["mediaResolution"]; !ok {
+			genCfg["mediaResolution"] = mr
 		}
 	}
+	setupInner["generationConfig"] = genCfg
 
 	// Use config-provided realtimeInputConfig, or defaults
 	if p.liveConfig.RealtimeInputConfig != nil {
@@ -123,8 +132,16 @@ func (p *VertexLiveProvider) SetupMessage(model string) []byte {
 			"automaticActivityDetection": map[string]interface{}{
 				"disabled":                 false,
 				"startOfSpeechSensitivity": "START_SENSITIVITY_LOW",
-				"endOfSpeechSensitivity":   "END_SENSITIVITY_LOW",
+				"endOfSpeechSensitivity":   "END_SENSITIVITY_HIGH",
+				"silenceDurationMs":        500,
 			},
+		}
+	}
+
+	// Set the system instruction (role/persona/task) when configured.
+	if prompt := p.liveConfig.SystemPrompt; prompt != "" {
+		setupInner["systemInstruction"] = map[string]interface{}{
+			"parts": []map[string]interface{}{{"text": prompt}},
 		}
 	}
 


### PR DESCRIPTION
Live API video latency (0.5.15):
- Default endOfSpeechSensitivity END_SENSITIVITY_HIGH + silenceDurationMs 500 so turns commit sooner and the model processes the latest frame faster.
- New live.media_resolution (default MEDIA_RESOLUTION_LOW, ~280 tokens/frame) injected into generationConfig.mediaResolution.
- Snapshot button in examples/live-api/index-video.html sends the current frame as clientContent + turnComplete to force an immediate "look".
- handleUpstreamToolCalls runs off the proxy loop so slow tool calls no longer stall audio/video forwarding.

Live API system prompt / systemInstruction (0.5.16):
- New LiveConfig fields system_prompt, system_prompt_file, use_agent_prompt (+ PEPEBOT_LIVE_* env), with file loading in LoadConfig.
- vertex_live.go / gemini_live.go SetupMessage inject systemInstruction from config.
- live.go: SetupConfig.system_prompt per-session override, injectGeminiSystemInstruction, precedence resolution (client > config > agent persona), optional SystemPromptSource.
- AgentManager.LiveSystemPrompt reads AGENTS.md/SOUL.md/IDENTITY.md as opt-in fallback.
- No regression when unset: upstream setup is byte-identical (covered by tests).